### PR TITLE
fix: 悬停翻译自动聚焦 hover，导致编辑器丢失焦点

### DIFF
--- a/src/command/select.ts
+++ b/src/command/select.ts
@@ -60,7 +60,7 @@ export function mouseToSelect(context: ExtensionContext) {
             let selectionText = e.textEditor.document.getText(selections[0]);
             if(selectionText.length > 1000) return;
             if(isCode(selectionText)) return;
-            commands.executeCommand('editor.action.showHover');
+            commands.executeCommand('editor.action.showHover', { focus: "noAutoFocus" });
             lastShowHover = (new Date()).getTime();
         }, laterTime);
     }));


### PR DESCRIPTION
修复以下问题：
* fixes https://github.com/intellism/vscode-comment-translate/issues/181
* fixes https://github.com/intellism/vscode-comment-translate/issues/195

具体细节讨论，请移步：https://github.com/intellism/vscode-comment-translate/issues/181, https://github.com/microsoft/vscode/pull/196891

**⚠️ 注意：**

此 PR 需要等到 https://github.com/microsoft/vscode/pull/200237 合并，并且 VS Code 发布 v1.86.0 版本后生效。

届时，使用 VS Code`>=1.73.0 <1.86.0` 版本的用户，需要更新到 VS Code `>=1.86.0`。