### PR TITLE
docs: add new external translation source

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,9 @@
 * `commentTranslate.googleTranslate.mirror`，解决国内服务不可访问问题. [文档](https://hcfy.app/blog/2022/09/28/ggg#%E6%96%B9%E6%A1%88-c%E4%BD%BF%E7%94%A8%E9%95%9C%E5%83%8F%E5%9C%B0%E5%9D%80%E6%9C%80%E7%AE%80%E5%8D%95)
 
 ## 翻译源
-* 支持外部“翻译源”扩展。目前外部插件已支持 [ChatGPT](https://marketplace.visualstudio.com/items?itemName=kitiho.chatgpt-comment-translate) & [DeepL](https://marketplace.visualstudio.com/items?itemName=intellsmi.deepl-translate) & [tencent cloud](https://marketplace.visualstudio.com/items?itemName=Kaiqun.tencent-cloud-translate) 翻译源. 
+* 支持外部“翻译源”扩展。目前外部插件已支持:
+  * [ChatGPT 支持反代 API](https://marketplace.visualstudio.com/items?itemName=upupnoah.chatgpt-comment-translateX)
+  * [ChatGPT](https://marketplace.visualstudio.com/items?itemName=kitiho.chatgpt-comment-translate)
+  * [DeepL](https://marketplace.visualstudio.com/items?itemName=intellsmi.deepl-translate)
+  * [Tecent Cloud](https://marketplace.visualstudio.com/items?itemName=Kaiqun.tencent-cloud-translate) 
 * 已内置Ali翻译源。 可以通过 [开通阿里云机器翻译](https://www.aliyun.com/product/ai/alimt) 生成 accessKeyId & accessKeySecret ,并配置到插件中。切换对应翻译源，获得更稳定的翻译服务


### PR DESCRIPTION
Based on ChatGPT, reverse proxy API and custom models have been added to the external translation source.